### PR TITLE
feat: emit llms.txt and per-page Markdown output

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/ngs/ja.ngs.io
 
 go 1.24.6
 
-require go.ngs.io/hugo-primer-blog v1.0.8 // indirect
+require go.ngs.io/hugo-primer-blog v1.0.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-go.ngs.io/hugo-primer-blog v1.0.8 h1:jsX9iX6qfvErZlSELLFijT0ptHsXAJSUMQGxeaS1ZvA=
-go.ngs.io/hugo-primer-blog v1.0.8/go.mod h1:ofMy3Zqvt6gpBuiKLg9BJV3SvTB6sMsNWPyZj7LUY0w=
+go.ngs.io/hugo-primer-blog v1.0.9 h1:WN/DiNcw7cc8kVAoMWWTrzeU03lUv/YY5lZrlDOQ27k=
+go.ngs.io/hugo-primer-blog v1.0.9/go.mod h1:ofMy3Zqvt6gpBuiKLg9BJV3SvTB6sMsNWPyZj7LUY0w=

--- a/hugo.toml
+++ b/hugo.toml
@@ -13,6 +13,11 @@ path = "go.ngs.io/hugo-primer-blog"
 [markup.goldmark.renderer]
 unsafe = true
 
+# Output formats (LLMS / Markdown) are defined by the theme; opt in here.
+[outputs]
+home = ["HTML", "RSS", "LLMS"]
+page = ["HTML", "Markdown"]
+
 [params]
 author = "長瀬 敦史"
 defaultTheme = "auto"


### PR DESCRIPTION
## 概要

LLM 向け出力を有効化します（ngs.io と同内容）。

- ホームに `llms.txt`（記事一覧のサイトインデックス）を生成
- 各ページに生の Markdown 版 `index.md` を `index.html` と並べて生成

参考: https://ravichaganti.com/blog/implementing-llms.txt-and-markdown-output-in-hugo/

## 変更点

- `hugo.toml` に `[outputs]` を追加し、`LLMS`（home）と `Markdown`（page）をオプトイン
- `hugo-primer-blog` を `v1.0.9` に更新（`LLMS` / `Markdown` 出力フォーマットの定義とテンプレートを提供）

出力フォーマットの定義とテンプレート本体はテーマ側（[hugo-primer-blog#v1.0.9](https://github.com/ngs/hugo-primer-blog/releases/tag/v1.0.9)）にあります。`outputs` キーはテーマ設定からマージされない（merge strategy が `none`）ため、本リポジトリでオプトインしています。

## 確認

- `public/llms.txt` 生成 ✅
- 各記事の `index.md` 生成 ✅
- 既存の `index.xml`（RSS）維持 ✅

## 備考

`update-dependents.yml` が自動生成した go.mod/go.sum のみの PR は、本 PR が包含するためクローズします。